### PR TITLE
研究業績追加：ヒューマンインタフェース学会論文誌の共著論文

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -106,6 +106,14 @@ const translations = {
     research: {
       title: "Research",
       subtitle: "研究・論文",
+      paper6: {
+        year: "2026",
+        title: "多話者環境における目的音声抽出の有効性と課題―ろう・難聴者の主観評価に基づく分析―",
+        venue: "ヒューマンインタフェース学会論文誌, 28(2), pp. 165-174",
+        description: "ニューラルネットワークによる目的音声抽出がろう・難聴者の聴取努力に与える効果を，序数ロジスティック混合モデルで定量的に分析．効果は低～中SNRで最も顕著だった．",
+        link: "Paper",
+        tags: ["共著", "論文誌"]
+      },
       paper5: {
         year: "2025",
         title: "Empirical Study on Listening Effort of Deaf and Hard-of-Hearing for Enhanced Speech in Multispeaker Environments",
@@ -358,6 +366,14 @@ const translations = {
     research: {
       title: "Research",
       subtitle: "Research & Publications",
+      paper6: {
+        year: "2026",
+        title: "Effectiveness and Challenges of Target-Speech Extraction in Multispeaker Environments: A Subjective Evaluation by Deaf and Hard-of-Hearing Participants",
+        venue: "Journal of Human Interface Society, 28(2), pp. 165-174",
+        description: "Quantified how neural network-based target-speech extraction affects listening effort for deaf/hard-of-hearing participants, using ordinal logistic mixed models and hierarchical Bayesian extensions. Benefits were most pronounced at low-to-mid SNRs.",
+        link: "Paper",
+        tags: ["Co-author", "Journal"]
+      },
       paper5: {
         year: "2025",
         title: "Empirical Study on Listening Effort of Deaf and Hard-of-Hearing for Enhanced Speech in Multispeaker Environments",

--- a/index.html
+++ b/index.html
@@ -310,6 +310,18 @@
       <div class="steel-shelf">
         <div class="research-grid">
           <article class="research-item">
+            <div class="research-year" data-i18n="research.paper6.year"></div>
+            <div class="research-tags" data-i18n-list="research.paper6.tags"></div>
+            <h3 class="research-title" data-i18n="research.paper6.title"></h3>
+            <p class="research-venue" data-i18n="research.paper6.venue"></p>
+            <p class="research-desc" data-i18n="research.paper6.description"></p>
+            <div class="research-links">
+              <a href="https://www.jstage.jst.go.jp/article/his/28/2/28_165/_article/-char/ja" target="_blank"
+                data-i18n="research.paper6.link"></a>
+            </div>
+          </article>
+
+          <article class="research-item">
             <div class="research-year" data-i18n="research.paper5.year"></div>
             <div class="research-tags" data-i18n-list="research.paper5.tags"></div>
             <h3 class="research-title" data-i18n="research.paper5.title"></h3>


### PR DESCRIPTION
## 概要
共著論文がヒューマンインタフェース学会論文誌に掲載されたため、Researchセクションに追加。

## 論文情報
- **タイトル**：多話者環境における目的音声抽出の有効性と課題―ろう・難聴者の主観評価に基づく分析―
- **掲載誌**：ヒューマンインタフェース学会論文誌, 28(2), pp. 165-174 (2026)
- **タグ**：共著 / 論文誌
- **リンク**：https://www.jstage.jst.go.jp/article/his/28/2/28_165/_article/-char/ja

## 変更内容
- `index.html`：Researchグリッド先頭に paper6 ブロックを追加
- `i18n.js`：日英両方に paper6 エントリを追加（英題は正式版、英descriptionはアブスト反映）

🤖 Generated with [Claude Code](https://claude.com/claude-code)