### PR TITLE
Apps セクションに「にじいろスライム」を追加

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -100,6 +100,13 @@ const translations = {
         description: "音源の周波数成分を可視光スペクトルの色で描画．",
         tech: ["JavaScript", "WebAudio"],
         link: "GitHub →"
+      },
+      nijiiroSlime: {
+        name: "にじいろスライム",
+        tag: "Game",
+        description: "同じスライムをくっつけて色を育てる合体パズル．2048で「にじいろスライム」，4096で「やみスライム」が生まれます．",
+        tech: ["JavaScript", "Canvas", "ブラウザ"],
+        link: "あそぶ →"
       }
     },
     // Researchセクション
@@ -360,6 +367,13 @@ const translations = {
         description: "Visualize audio frequency components as visible light spectrum colors.",
         tech: ["JavaScript", "WebAudio"],
         link: "GitHub →"
+      },
+      nijiiroSlime: {
+        name: "Nijiiro Slime",
+        tag: "Game",
+        description: "A merge puzzle where matching slimes fuse and grow more colorful. Reach 2048 for the rainbow slime, 4096 for the dark slime.",
+        tech: ["JavaScript", "Canvas", "Browser"],
+        link: "Play →"
       }
     },
     // Research section

--- a/index.html
+++ b/index.html
@@ -293,6 +293,24 @@
               </div>
             </div>
 
+            <!-- にじいろスライム -->
+            <div class="app-card" data-flipped="false">
+              <div class="card-inner">
+                <div class="card-front">
+                  <span class="app-icon">🫧</span>
+                  <h3 class="app-name" data-i18n="apps.nijiiroSlime.name"></h3>
+                  <span class="app-tag" data-i18n="apps.nijiiroSlime.tag"></span>
+                </div>
+                <div class="card-back">
+                  <h3 data-i18n="apps.nijiiroSlime.name"></h3>
+                  <p data-i18n="apps.nijiiroSlime.description"></p>
+                  <div class="card-tech" data-i18n-list="apps.nijiiroSlime.tech"></div>
+                  <a href="https://slime.fujiemon.dev/" target="_blank" class="card-link"
+                    data-i18n="apps.nijiiroSlime.link"></a>
+                </div>
+              </div>
+            </div>
+
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要

新しくサブドメイン公開したブラウザゲーム **にじいろスライム**（https://slime.fujiemon.dev/）へのリンクを、トップページの Apps セクションに追加します。

リポジトリ: https://github.com/shotafujie/nijiiro-slime

## 変更内容

- `index.html`: Apps セクション末尾（SoundHue の後）にカードを1枚追加。アイコン 🫧、リンク先は GitHub ではなくゲーム本体
- `i18n.js`: `apps.nijiiroSlime` を ja / en 両方に追加（リンク文言は「あそぶ →」/「Play →」）

## 検証

`index.html` 内の `data-i18n` / `data-i18n-list` / `data-i18n-aria` キー **154件すべてが ja / en 双方で解決すること**をスクリプトで確認済み（missing=0）。

ブラウザでの見た目は未確認です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)