### PR TITLE
静的アセット参照にバージョンクエリを付与（デプロイ直後の表示崩れを修正）

### DIFF
--- a/hobbies.html
+++ b/hobbies.html
@@ -20,7 +20,7 @@
   <meta name="twitter:card" content="summary_large_image">
 
 
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=2.1.2">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
   <meta name="twitter:description" content="ふじえもんのホームページです．成果物や登壇資料を掲載しています．">
   <meta name="twitter:image" content="https://fujiemon.dev/image/fujiemon.png">
 
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=2.1.2">
 </head>
 
 <body>
@@ -646,8 +646,10 @@
     </div>
   </footer>
 
-  <script src="i18n.js"></script>
-  <script src="main.js"></script>
+  <!-- ?v= は必ず更新すること。i18n.js / main.js は Cache-Control: max-age=14400 で
+       配信されるため、付けないと HTML だけ新しく JS が古い状態が最大4時間続く。 -->
+  <script src="i18n.js?v=2.1.2"></script>
+  <script src="main.js?v=2.1.2"></script>
 </body>
 
 </html>

--- a/slides.html
+++ b/slides.html
@@ -20,7 +20,7 @@
   <meta name="twitter:card" content="summary_large_image">
 
 
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=2.1.2">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## 問題

v2.1.1 で追加した「にじいろスライム」カードが、既訪問者のブラウザで**中身が空のまま**表示されていた。

原因は GitHub Pages の Cache-Control の差:

| ファイル | Cache-Control |
|---|---|
| `index.html` | `max-age=600`（10分） |
| `i18n.js` / `main.js` / `style.css` | `max-age=14400`（**4時間**） |

HTML だけ先に更新され、翻訳データを持つ `i18n.js` は最大4時間古いまま。結果として `data-i18n="apps.nijiiroSlime.*"` がどのキーにも解決せず、`main.js` は値が無いと `textContent` を書き換えないため、カードが空欄になる。

これはカード追加に限らず、**今後 i18n.js / main.js / style.css を変更するたびに起きる**。

## 修正

`script` / `link` の参照に `?v=2.1.2` を付与。リリースのたびに更新する（HTML 側にコメントで明記）。

- `index.html`: `style.css` / `i18n.js` / `main.js`
- `hobbies.html`, `slides.html`: `style.css`

## 検証

参照先3ファイルすべてについて、実ファイルの存在とバージョン文字列の一致をスクリプトで確認。`hobbies.html` 内の YouTube リンク（`?v=` を含む）は誤置換していないことも確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)