### PR TITLE
にじいろスライムの説明文を短縮してカード内に収める

### DIFF
--- a/hobbies.html
+++ b/hobbies.html
@@ -20,7 +20,7 @@
   <meta name="twitter:card" content="summary_large_image">
 
 
-  <link rel="stylesheet" href="style.css?v=2.1.2">
+  <link rel="stylesheet" href="style.css?v=2.1.3">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/i18n.js
+++ b/i18n.js
@@ -104,7 +104,7 @@ const translations = {
       nijiiroSlime: {
         name: "にじいろスライム",
         tag: "Game",
-        description: "同じスライムをくっつけて色を育てる合体パズル．2048で「にじいろスライム」，4096で「やみスライム」が生まれます．",
+        description: "同じスライムをくっつけて色を育てる合体パズル．2048で「にじいろスライム」が生まれます．",
         tech: ["JavaScript", "Canvas", "ブラウザ"],
         link: "あそぶ →"
       }
@@ -371,7 +371,7 @@ const translations = {
       nijiiroSlime: {
         name: "Nijiiro Slime",
         tag: "Game",
-        description: "A merge puzzle where matching slimes fuse and grow more colorful. Reach 2048 for the rainbow slime, 4096 for the dark slime.",
+        description: "A merge puzzle where matching slimes fuse and grow more colorful. Reach 2048 for the rainbow slime.",
         tech: ["JavaScript", "Canvas", "Browser"],
         link: "Play →"
       }

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
   <meta name="twitter:description" content="ふじえもんのホームページです．成果物や登壇資料を掲載しています．">
   <meta name="twitter:image" content="https://fujiemon.dev/image/fujiemon.png">
 
-  <link rel="stylesheet" href="style.css?v=2.1.2">
+  <link rel="stylesheet" href="style.css?v=2.1.3">
 </head>
 
 <body>
@@ -648,8 +648,8 @@
 
   <!-- ?v= は必ず更新すること。i18n.js / main.js は Cache-Control: max-age=14400 で
        配信されるため、付けないと HTML だけ新しく JS が古い状態が最大4時間続く。 -->
-  <script src="i18n.js?v=2.1.2"></script>
-  <script src="main.js?v=2.1.2"></script>
+  <script src="i18n.js?v=2.1.3"></script>
+  <script src="main.js?v=2.1.3"></script>
 </body>
 
 </html>

--- a/slides.html
+++ b/slides.html
@@ -20,7 +20,7 @@
   <meta name="twitter:card" content="summary_large_image">
 
 
-  <link rel="stylesheet" href="style.css?v=2.1.2">
+  <link rel="stylesheet" href="style.css?v=2.1.3">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## 問題

説明文が長く、カード裏面の領域からはみ出して「あそぶ →」リンクがカードの外に描画されていた。

## 修正

4096（やみスライム）の記述を削除し、既存カードと同程度の文字数に揃えた。

| | 変更前 | 変更後 |
|---|---|---|
| ja | 60文字 | **45文字** |
| en | 123文字 | **99文字** |

ja の45文字は既存の最長カード（arXiv2Discord: 45文字）と同じ、asrivia（44文字・タグ5個）も収まっているため、タグ3個の本カードは収まる想定。

あわせて `i18n.js` を変更したため、v2.1.2 で導入したアセットのバージョンクエリを `?v=2.1.3` に更新。

## 検証

`data-i18n` 系キー154件が ja / en 双方で解決することを再確認（missing=0）。**ブラウザでの描画は未確認**なので、マージ後に実機で見え方を確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)